### PR TITLE
Allow to override AWS Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The AWS S3 build cache implementation has a few configuration options:
 | `path` | The path under which all cache objects should be stored. | no | |
 | `reducedRedundancy` | Whether or not to use [reduced redundancy](https://aws.amazon.com/s3/reduced-redundancy/). | no | true |
 | `endpoint` | Alternative S3 compatible endpoint | no | |
+| `awsAccessKeyId` | The AWS access key id | no | from DefaultAWSCredentialsProviderChain |
+| `awsSecretKey` | The AWS secret key | no | from DefaultAWSCredentialsProviderChain |
 
 
 The `buildCache` configuration block might look like this:
@@ -79,6 +81,8 @@ More details about configuring the Gradle build cache can be found in the
 
 The plugin uses the [`DefaultAWSCredentialsProviderChain`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
 to look up the AWS credentials.
+If you want to override the credentials feel free to set `awsAccessKeyId` and `awsSecretKey` and the plugin will ignore
+`DefaultAWSCredentialsProviderChain`.
 
 ### S3 Bucket Permissions
 

--- a/src/main/java/ch/myniva/gradle/caching/s3/AwsS3BuildCache.java
+++ b/src/main/java/ch/myniva/gradle/caching/s3/AwsS3BuildCache.java
@@ -24,6 +24,8 @@ public class AwsS3BuildCache extends AbstractBuildCache {
   private String path;
   private boolean reducedRedundancy = true;
   private String endpoint;
+  private String awsAccessKeyId;
+  private String awsSecretKey;
 
   public String getRegion() {
     return region;
@@ -63,5 +65,21 @@ public class AwsS3BuildCache extends AbstractBuildCache {
 
   public void setEndpoint(String endpoint) {
     this.endpoint = endpoint;
+  }
+
+  public String getAwsAccessKeyId() {
+    return awsAccessKeyId;
+  }
+
+  public void setAwsAccessKeyId(String awsAccessKeyId) {
+    this.awsAccessKeyId = awsAccessKeyId;
+  }
+
+  public String getAwsSecretKey() {
+    return awsSecretKey;
+  }
+
+  public void setAwsSecretKey(String awsSecretKey) {
+    this.awsSecretKey = awsSecretKey;
   }
 }

--- a/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
+++ b/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
@@ -74,7 +74,7 @@ public class AwsS3BuildCacheServiceFactory implements BuildCacheServiceFactory<A
     AmazonS3 s3;
     try {
       AmazonS3ClientBuilder s3Builder = AmazonS3ClientBuilder.standard();
-      if (config.getAwsAccessKeyId() != null && config.getAwsSecretKey() != null) {
+      if (!isNullOrEmpty(config.getAwsAccessKeyId()) && !isNullOrEmpty(config.getAwsSecretKey())) {
         s3Builder.withCredentials(new AWSStaticCredentialsProvider(
             new BasicAWSCredentials(config.getAwsAccessKeyId(), config.getAwsSecretKey())));
       }

--- a/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
+++ b/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
@@ -16,20 +16,22 @@
 
 package ch.myniva.gradle.caching.s3.internal;
 
-import ch.myniva.gradle.caching.s3.AwsS3BuildCache;
+import static com.amazonaws.util.StringUtils.isNullOrEmpty;
+
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
 import org.gradle.api.GradleException;
 import org.gradle.caching.BuildCacheService;
 import org.gradle.caching.BuildCacheServiceFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.amazonaws.util.StringUtils.isNullOrEmpty;
+import ch.myniva.gradle.caching.s3.AwsS3BuildCache;
 
 public class AwsS3BuildCacheServiceFactory implements BuildCacheServiceFactory<AwsS3BuildCache> {
 

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building version
-version=0.6.1
+version=0.7.0
 
 #Previous version used to generate release notes delta
 previousVersion=0.6.0


### PR DESCRIPTION
We have projects that use AWS for integration tests, so they set their AWS credentials and are not able to access the BuildCache S3 bucket.

I've just added the 2 properties to allow people to use any credentials they want.

What I haven't figured out yet is how to test it's working.