### PR TITLE
Add  AWS session token to credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The AWS S3 build cache implementation has a few configuration options:
 | `headers` | A map with HTTP headers to be added to each request (nulls are ignored). e.g. `[ 'x-header-name': 'header-value' ]` | no | |
 | `awsAccessKeyId` | The AWS access key id | no | from DefaultAWSCredentialsProviderChain |
 | `awsSecretKey` | The AWS secret key | no | from DefaultAWSCredentialsProviderChain |
+| `sessionToken` | The AWS sessionToken when you use temporal credentials | no | from DefaultAWSCredentialsProviderChain |
 
 
 The `buildCache` configuration block might look like this:
@@ -83,8 +84,8 @@ More details about configuring the Gradle build cache can be found in the
 
 The plugin uses the [`DefaultAWSCredentialsProviderChain`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html)
 to look up the AWS credentials.
-If you want to override the credentials feel free to set `awsAccessKeyId` and `awsSecretKey` and the plugin will ignore
-`DefaultAWSCredentialsProviderChain`.
+If you want to override the credentials feel free to set `awsAccessKeyId` and `awsSecretKey` and (optionally depends on
+configuration) `sessionToken`. If they are set the plugin will ignore `DefaultAWSCredentialsProviderChain`.
 
 ### S3 Bucket Permissions
 

--- a/src/main/java/ch/myniva/gradle/caching/s3/AwsS3BuildCache.java
+++ b/src/main/java/ch/myniva/gradle/caching/s3/AwsS3BuildCache.java
@@ -29,6 +29,7 @@ public class AwsS3BuildCache extends AbstractBuildCache {
   private Map<String, String> headers;
   private String awsAccessKeyId;
   private String awsSecretKey;
+  private String sessionToken;
 
   public String getRegion() {
     return region;
@@ -92,5 +93,13 @@ public class AwsS3BuildCache extends AbstractBuildCache {
 
   public void setAwsSecretKey(String awsSecretKey) {
     this.awsSecretKey = awsSecretKey;
+  }
+
+  public String getSessionToken() {
+    return sessionToken;
+  }
+
+  public void setSessionToken(String sessionToken) {
+    this.sessionToken = sessionToken;
   }
 }

--- a/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
+++ b/src/main/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactory.java
@@ -22,6 +22,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -75,7 +76,12 @@ public class AwsS3BuildCacheServiceFactory implements BuildCacheServiceFactory<A
     AmazonS3 s3;
     try {
       AmazonS3ClientBuilder s3Builder = AmazonS3ClientBuilder.standard();
-      if (!isNullOrEmpty(config.getAwsAccessKeyId()) && !isNullOrEmpty(config.getAwsSecretKey())) {
+      if (!isNullOrEmpty(config.getAwsAccessKeyId()) && !isNullOrEmpty(config.getAwsSecretKey()) &&
+                !isNullOrEmpty(config.getSessionToken())) {
+            s3Builder.withCredentials(new AWSStaticCredentialsProvider(
+                    new BasicSessionCredentials(config.getAwsAccessKeyId(), config.getAwsSecretKey(),
+                            config.getSessionToken())));
+      } else if (!isNullOrEmpty(config.getAwsAccessKeyId()) && !isNullOrEmpty(config.getAwsSecretKey())) {
         s3Builder.withCredentials(new AWSStaticCredentialsProvider(
             new BasicAWSCredentials(config.getAwsAccessKeyId(), config.getAwsSecretKey())));
       }

--- a/src/test/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactoryTest.java
+++ b/src/test/java/ch/myniva/gradle/caching/s3/internal/AwsS3BuildCacheServiceFactoryTest.java
@@ -119,6 +119,20 @@ public class AwsS3BuildCacheServiceFactoryTest {
     subject.createBuildCacheService(conf, buildCacheDescriber);
   }
 
+  @Test
+  public void testAddAWSSessionCredentials() throws Exception {
+    AwsS3BuildCache conf = new AwsS3BuildCache();
+    conf.setBucket("my-bucket");
+    conf.setRegion("us-west-1");
+    conf.setAwsAccessKeyId("any aws access key");
+    conf.setAwsSecretKey("any secret key");
+    conf.setSessionToken("any session token");
+
+    BuildCacheService service = subject.createBuildCacheService(conf, buildCacheDescriber);
+
+    assertNotNull(service);
+  }
+
   private class NoopBuildCacheDescriber implements Describer {
 
     @Override

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Currently building version
-version=0.8.1
+version=0.9.0
 
 #Previous version used to generate release notes delta
 previousVersion=0.8.0


### PR DESCRIPTION
Congratulation for the project! Super useful for us using S3 like Remote Build Cache. 

We have done a little change in order to use the AWS credentials as we are using AWS STS credentials which require the session token. 

> AWS uses the session token to validate the temporary security credentials.  https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

The PR just add a new check to previous `BasicAWSCredentials` using instead of `BasicSessionCredentials`

