### PR TITLE
Don't use a dynamic version for com.amazonaws:aws-java-sdk-s3.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 dependencies {
-    compile 'com.amazonaws:aws-java-sdk-s3:1.+'
+    compile 'com.amazonaws:aws-java-sdk-s3:1.11.539'
 
     testCompile 'junit:junit:4.+'
     testCompile 'org.mockito:mockito-core:2.+'


### PR DESCRIPTION
Fixes #20.