### PR TITLE
Pin build env to Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 
 script:
   - ./gradlew check -s
@@ -12,4 +14,3 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-


### PR DESCRIPTION
Stick with this version of Java till v2.0 of the plugin for compatibility reasons.